### PR TITLE
Issue #7 fix undo/redo for HermeneutiX module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
   - openjdk7
   

--- a/scitos.ais/scitos.ais.view/src/test/java/org/hmx/scitos/ais/view/swing/AisViewProjectTest.java
+++ b/scitos.ais/scitos.ais.view/src/test/java/org/hmx/scitos/ais/view/swing/AisViewProjectTest.java
@@ -20,14 +20,12 @@
 package org.hmx.scitos.ais.view.swing;
 
 import java.awt.Component;
-import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JTextPane;
 
@@ -45,7 +43,6 @@ import org.hmx.scitos.view.FileType;
 import org.hmx.scitos.view.swing.AbstractScitosUiTest;
 import org.hmx.scitos.view.swing.components.ScaledTable;
 import org.hmx.scitos.view.swing.util.OrdinalComponentMatcher;
-import org.hmx.scitos.view.swing.util.ToolTipComponentMatcher;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,12 +51,6 @@ import com.thedeanda.lorem.LoremIpsum;
 
 /** UI test for a simple AIS project workflow. */
 public class AisViewProjectTest extends AbstractScitosUiTest {
-
-    /**
-     * The default modifier key mask (on most systems {@link InputEvent#CTRL_DOWN_MASK}, e.g. on Mac OS X {@link InputEvent#META_DOWN_MASK} i.e. the
-     * command button).
-     */
-    private final int menuShortcutMask = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
     /**
      * Test for a simple AIS project workflow with the following steps:
@@ -103,7 +94,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
         // #4 assign and unassign detail categories via mouse (i.e. mouse selection and clicking on tool bar buttons)
         this.assignDetailsToFirstInterview(textOneTokens);
         // #5 add an interview for another participant
-        this.frame.toolBar().button(new ToolTipComponentMatcher<JButton>(JButton.class, AisMessage.INTERVIEW_NEW.get(), true)).click();
+        this.getToolBarButtonByToolTip(AisMessage.INTERVIEW_NEW).click();
         participantIdDialog = this.frame.optionPane().requireMessage(AisMessage.INTERVIEW_NEW_PARTICIPANTID.get());
         final String participantTwo = textGenerator.getNameMale();
         participantIdDialog.textBox().setText(participantTwo);
@@ -118,7 +109,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
         // #8 navigate back to the first interview via the project tree and undo the last action
         this.projectTree.clickPath(AisMessage.PROJECT_UNSAVED.get() + '/' + participantOne);
         // detail assignment: I1 - E3 -(I2 - ..I2)- ..E3 - ..E3
-        this.frame.toolBar().button(new ToolTipComponentMatcher<JButton>(JButton.class, Message.MENUBAR_EDIT_UNDO.get(), true)).click();
+        this.getUndoToolBarButton().click();
         this.assertTextTokenStates_BeforeLastRemoval(textOneTokens);
         // #9 navigate to project overview via its tab and confirm displayed results
         this.tabbedPane.selectTab(AisMessage.PROJECT_UNSAVED.get());
@@ -130,7 +121,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
     /**
      * Assign and unassign detail categories via mouse (i.e. mouse selection and clicking on tool bar buttons). The resulting detail assignments
      * should represent the following structure: {@code Int1 Ext3 (Int2 ..Int2 __) ..Ext3}
-     * 
+     *
      * @param tokenTexts
      *            texts of the interview's tokens
      */
@@ -169,7 +160,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
     /**
      * Assign and unassign detail categories via keyboard shortcuts (i.e. selection via arrow keys and assigning details via shortcuts). The resulting
      * detail assignments should represent the following structure: {@code Int1 Ext3 (Int2 ..Int2 __) ..Ext3}
-     * 
+     *
      * @param tokenTexts
      *            texts of the interview's tokens
      */
@@ -211,7 +202,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
 
     /**
      * Getter for the text label on the component representing the n-th text token.
-     * 
+     *
      * @param ordinal
      *            index of the designated text token (component)
      * @return the {@code TextTokenComponent}'s text label's fixture
@@ -223,7 +214,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
     /**
      * Assert the final states of the currently visible interview's text tokens equals the following detail structure:
      * {@code Int1 Ext3 (Int2 ..Int2) ..Ext3 ..Ext3}
-     * 
+     *
      * @param tokenTexts
      *            expected texts of the individual tokens
      */
@@ -241,7 +232,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
     /**
      * Assert the final states of the currently visible interview's text tokens equals the following detail structure:
      * {@code Int1 Ext3 (Int2 ..Int2 __) ..Ext3}
-     * 
+     *
      * @param tokenTexts
      *            expected texts of the individual tokens
      */
@@ -258,7 +249,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
 
     /**
      * Getter for components representing text tokens (including their potentially assigned detail category).
-     * 
+     *
      * @return {@code TextTokenComponent} fixtures
      */
     private List<JPanelFixture> getTextTokenComponents() {
@@ -272,7 +263,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
 
     /**
      * Assert a single text token component's properties, without expecting any opening or closing brackets.
-     * 
+     *
      * @param textTokenComponent
      *            the text token component to assert
      * @param text
@@ -286,7 +277,7 @@ public class AisViewProjectTest extends AbstractScitosUiTest {
 
     /**
      * Assert a single text token component's properties.
-     * 
+     *
      * @param textTokenComponent
      *            the text token component to assert
      * @param text

--- a/scitos.core/src/main/java/org/hmx/scitos/core/AbstractModelHandler.java
+++ b/scitos.core/src/main/java/org/hmx/scitos/core/AbstractModelHandler.java
@@ -36,7 +36,7 @@ import org.hmx.scitos.domain.util.CollectionUtil;
 public abstract class AbstractModelHandler<M extends IModel<M>> implements IModelHandler<M> {
 
     /** The managed model object. */
-    private final M model;
+    private M model;
     /** The listeners that are notified when a model change occurs. */
     private final List<ModelChangeListener> listeners;
 
@@ -54,6 +54,10 @@ public abstract class AbstractModelHandler<M extends IModel<M>> implements IMode
     @Override
     public M getModel() {
         return this.model;
+    }
+
+    protected void setModel(final M model) {
+        this.model = model;
     }
 
     @Override

--- a/scitos.core/src/main/java/org/hmx/scitos/core/option/Option.java
+++ b/scitos.core/src/main/java/org/hmx/scitos/core/option/Option.java
@@ -39,9 +39,9 @@ public enum Option implements IOptionSetting {
     /** For usability: last directory used for saving. */
     WORKDIR("WorkDir", null),
     /** For usability: window width in the last session. */
-    WINDOW_WIDTH("Window.Width", "800"),
+    WINDOW_WIDTH("Window.Width", "1000"),
     /** For usability: window height in the last session. */
-    WINDOW_HEIGHT("Window.Height", "600"),
+    WINDOW_HEIGHT("Window.Height", "700"),
     /** For usability: left border of the window in the last session. */
     WINDOW_X_LOCATION("Window.PosX", "0"),
     /** For usability: top border of the window in the last session. */

--- a/scitos.hmx/scitos.hmx.core/src/main/java/org/hmx/scitos/hmx/core/HmxModelHandler.java
+++ b/scitos.hmx/scitos.hmx.core/src/main/java/org/hmx/scitos/hmx/core/HmxModelHandler.java
@@ -40,6 +40,13 @@ import org.hmx.scitos.hmx.domain.model.SyntacticalFunction;
 public interface HmxModelHandler extends IModelHandler<Pericope> {
 
     /**
+     * Replace the managed model object with the given one, e.g. for use in an undo or redo action.
+     *
+     * @param model new managed model object
+     */
+    void resetModel(Pericope model);
+
+    /**
      * Set the title, author, and comment of the whole managed model, as well as the font used for the origin text.
      *
      * @param title

--- a/scitos.hmx/scitos.hmx.core/src/main/java/org/hmx/scitos/hmx/core/ModelHandlerImpl.java
+++ b/scitos.hmx/scitos.hmx.core/src/main/java/org/hmx/scitos/hmx/core/ModelHandlerImpl.java
@@ -59,6 +59,12 @@ public final class ModelHandlerImpl extends AbstractModelHandler<Pericope> imple
     }
 
     @Override
+    public void resetModel(final Pericope model) {
+        this.setModel(model);
+        this.notifyListeners(this.getModel(), false);
+    }
+
+    @Override
     public void setMetaData(final String title, final String author, final String comment, final String originTextFontFamily,
             final int originTextFontSize) {
         this.getModel().setTitle(title);
@@ -155,7 +161,7 @@ public final class ModelHandlerImpl extends AbstractModelHandler<Pericope> imple
     /**
      * Check if the {@link Proposition}s in the given order, have no {@link Proposition}s between them that are on the same or higher level. This
      * ignores the scenario where both {@link Proposition}s have the same parent or one of the two is the parent (or parent's parent...) of the other.
-     * 
+     *
      * @param propOne
      *            leading {@link Proposition} to check
      * @param propTwo
@@ -352,7 +358,7 @@ public final class ModelHandlerImpl extends AbstractModelHandler<Pericope> imple
      * Merge the given {@link Proposition}s by appending the {@code secondPart} to the {@code firstPart} WITHOUT REMOVING the {@code secondPart} from
      * its parent, which needs to be called separately. This method assumes both {@link Proposition}s being adjacent to one another and preserves any
      * (other) child {@link Proposition}s and handles potentially affected {@link Proposition} parts or enclosed children.
-     * 
+     *
      * @param prop1Part
      *            leading {@link Proposition} to receive the other {@link Proposition}'s {@link ClauseItem}s, translations, and child
      *            {@link Proposition}s
@@ -473,7 +479,7 @@ public final class ModelHandlerImpl extends AbstractModelHandler<Pericope> imple
 
     /**
      * Combine the two texts by separating them with the given character. If one of the texts is {@code null}, the other one is returned.
-     * 
+     *
      * @param textOne
      *            leading text to be merged
      * @param textTwo

--- a/scitos.hmx/scitos.hmx.core/src/main/java/org/hmx/scitos/hmx/core/ModelParseServiceImpl.java
+++ b/scitos.hmx/scitos.hmx.core/src/main/java/org/hmx/scitos/hmx/core/ModelParseServiceImpl.java
@@ -28,13 +28,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.MissingResourceException;
+import java.util.TreeMap;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -519,7 +519,7 @@ public class ModelParseServiceImpl implements IModelParseService<Pericope> {
     /**
      * Create a copy of the given list of {@link SyntacticalFunction}s, ensuring the absence of any additional data only related to the backwards
      * compatibility for reading the former (standalone) HermeneutiX files.
-     * 
+     *
      * @param possibleCompatibleFunctions
      *            list of functions to copy in a minimal/non-compatible way
      * @return deep copied list
@@ -576,7 +576,7 @@ public class ModelParseServiceImpl implements IModelParseService<Pericope> {
             }
         }
         final String userLanguage = Option.TRANSLATION.getValueAsLocale().getLanguage();
-        final Map<String, Element> availableModels = new HashMap<String, Element>();
+        final Map<String, Element> availableModels = new TreeMap<String, Element>();
         for (final Element modelNode : systemModelNodes) {
             // get the user language independent name of this model
             final String compatibleName = modelNode.getAttribute(ModelParseServiceImpl.ATT_LANGMODEL_NAME_COMPATIBLE);
@@ -591,7 +591,7 @@ public class ModelParseServiceImpl implements IModelParseService<Pericope> {
 
     /**
      * Parse all contained {@link LanguageModel}s from the given document.
-     * 
+     *
      * @param xml
      *            the document to parse the {@value #TAG_LANGMODEL} nodes from
      * @return successfully parsed {@link LanguageModel}s

--- a/scitos.hmx/scitos.hmx.view/pom.xml
+++ b/scitos.hmx/scitos.hmx.view/pom.xml
@@ -32,7 +32,19 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hmx</groupId>
+			<artifactId>scitos.view</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hmx</groupId>
 			<artifactId>scitos.hmx.core</artifactId>
+		</dependency>
+		<!-- test-lib: AssertJ Swing for functional GUI testing -->
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-swing-junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/IPericopeView.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/IPericopeView.java
@@ -26,9 +26,10 @@ import org.hmx.scitos.hmx.domain.ISemanticalRelationProvider;
 import org.hmx.scitos.hmx.domain.model.AbstractConnectable;
 import org.hmx.scitos.hmx.domain.model.Proposition;
 import org.hmx.scitos.hmx.view.swing.elements.AbstractCommentable;
+import org.hmx.scitos.view.swing.IUndoManagedView;
 
 /** Generic interface of a user view regardless of its actual implementation. */
-public interface IPericopeView extends ISemanticalRelationProvider {
+public interface IPericopeView extends ISemanticalRelationProvider, IUndoManagedView {
 
     /**
      * Getter for the model handler, responsible for all actual model changes and manager of any model change events.
@@ -36,9 +37,6 @@ public interface IPericopeView extends ISemanticalRelationProvider {
      * @return the associated model handler instance
      */
     HmxModelHandler getModelHandler();
-
-    /** Ensure all pending changes are completed before any new model changes are being applied. */
-    void submitChangesToModel();
 
     /**
      * Collect the list of selected {@link Proposition}s in the syntactical analysis, if it is currently active (i.e. displayed).

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/AbstractAnalysisPanel.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/AbstractAnalysisPanel.java
@@ -81,6 +81,11 @@ abstract class AbstractAnalysisPanel extends JPanel {
     public abstract void repaintPericope();
 
     /**
+     * Ensure that any pending changes have been submitted to the model handler for proper processing.
+     */
+    public abstract void submitChangesToModel();
+
+    /**
      * Getter for the {@link ModelChangeListener} handling updates of this panel.
      *
      * @return the associated model listener

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/SemAnalysisPanel.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/SemAnalysisPanel.java
@@ -175,7 +175,7 @@ public final class SemAnalysisPanel extends AbstractAnalysisPanel {
 
     /**
      * Hide/show the associate roles on the {@link Relation} column at the given index.
-     * 
+     *
      * @param level
      *            single relation level to fold/unfold (targets all levels, when is {@code -1})
      * @param fold
@@ -388,20 +388,26 @@ public final class SemAnalysisPanel extends AbstractAnalysisPanel {
         }
     }
 
+    @Override
+    public void submitChangesToModel() {
+        // only the propositions might have any pending changes (e.g. the label and translation fields)
+        if (this.propositionList != null) {
+            for (final SemProposition singleProposition : this.propositionList) {
+                singleProposition.submitChangesToModel();
+            }
+        }
+    }
+
     /**
      * Expose a mutable copy of the internal list of displayed {@link SemProposition}s.
-     * 
+     *
      * @return list containing all {@link Proposition} components in this view
      */
     public List<SemProposition> getPropositionList() {
         if (this.propositionList == null) {
             return null;
         }
-        final List<SemProposition> val = new ArrayList<SemProposition>();
-        for (final SemProposition singleViewProposition : this.propositionList) {
-            val.add(singleViewProposition);
-        }
-        return val;
+        return new ArrayList<SemProposition>(this.propositionList);
     }
 
     /**
@@ -413,9 +419,8 @@ public final class SemAnalysisPanel extends AbstractAnalysisPanel {
         int max = 0;
         for (final SemProposition singleProposition : this.propositionList) {
             Relation singleSuperordinated = singleProposition.getRepresented().getSuperOrdinatedRelation();
-            int depth = 0;
-            while (singleSuperordinated != null) {
-                depth++;
+            int depth;
+            for (depth = 0; singleSuperordinated != null; depth++) {
                 singleSuperordinated = singleSuperordinated.getSuperOrdinatedRelation();
             }
             max = Math.max(max, depth);
@@ -425,7 +430,7 @@ public final class SemAnalysisPanel extends AbstractAnalysisPanel {
 
     /**
      * Expose a mutable copy of the mapping of displayed {@link Relation} and their respective components.
-     * 
+     *
      * @return map containing all relations and their representations
      */
     public Map<Relation, SemRelation> getRelationMap() {

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/SynAnalysisPanel.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/SynAnalysisPanel.java
@@ -200,6 +200,14 @@ public final class SynAnalysisPanel extends AbstractAnalysisPanel {
         }
     }
 
+    @Override
+    public void submitChangesToModel() {
+        // only the propositions might have any pending changes (e.g. the label and translation fields)
+        for (final SynProposition singleProposition : this.propositionList) {
+            singleProposition.submitChangesToModel();
+        }
+    }
+
     /**
      * Collect all checked {@link Proposition}s in the displayed syntactical analysis.
      *
@@ -220,7 +228,7 @@ public final class SynAnalysisPanel extends AbstractAnalysisPanel {
 
     /**
      * Getter for the complete list of all displayed {@link Proposition}s in the correct (i.e. text) order.
-     * 
+     *
      * @return list of all displayed {@link SynProposition}s
      */
     public List<SynProposition> getPropositionList() {

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/AbstractProposition.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/AbstractProposition.java
@@ -138,16 +138,18 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
         final GridBagConstraints constraints = new GridBagConstraints();
         constraints.gridx = 0;
         constraints.gridy = 1;
+        this.checkBox.setName("Check Box");
         this.contentPane.add(this.checkBox, constraints);
         this.contentPane.add(this.checkBoxDummy, constraints);
         // labelField
+        this.labelField.setName("Label Input");
         this.labelField.setColumns(Proposition.MAX_LABEL_LENGTH - 1);
         this.labelField.setDocument(new Validation(Proposition.MAX_LABEL_LENGTH));
         this.labelField.addFocusListener(new FocusAdapter() {
 
             @Override
             public void focusLost(final FocusEvent event) {
-                AbstractProposition.this.lostFocusOnLabel();
+                AbstractProposition.this.submitLabelChanges();
             }
         });
         this.refreshLabelText();
@@ -163,15 +165,28 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
     }
 
     /**
-     * Deal with a label text which lost the focus and might have been changed.
+     * Ensure that any pending changes (e.g. in the label or translation field) are being submitted to the model handler.
      */
-    final void lostFocusOnLabel() {
+    public void submitChangesToModel() {
+        this.submitLabelChanges();
+        this.submitTranslationChanges();
+    }
+
+    /**
+     * Ensure that any changes in the label field are submitted to the model.
+     */
+    final void submitLabelChanges() {
         // only transfer if necessary
         final String labelText = this.labelField.getText();
         if (!ComparisonUtil.isNullOrEmptyAwareEqual(this.represented.getLabel(), labelText)) {
             this.getModelHandler().setLabelText(this.represented, labelText);
         }
     }
+
+    /**
+     * Ensure that any changes in the translation field are submitted to the model.
+     */
+    protected abstract void submitTranslationChanges();
 
     /**
      * Getter for the associated {@link HmxModelHandler} implementation.
@@ -217,9 +232,16 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
     /**
      * Initialize the bottom right part of the {@link Proposition} containing the text field for the translation.
      */
-    private final void initTranslationArea() {
+    private void initTranslationArea() {
+        this.translationField.setName("Translation Input");
         this.translationField.setDocument(new Validation(Proposition.MAX_TRANSLATION_LENGTH));
         this.refreshTranslation();
+        this.translationField.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusLost(final FocusEvent event) {
+                AbstractProposition.this.submitTranslationChanges();
+            }
+        });
         final GridBagConstraints constraints = new GridBagConstraints();
         constraints.fill = GridBagConstraints.HORIZONTAL;
         constraints.weighty = 1;
@@ -231,7 +253,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the identifier's input field.
-     * 
+     *
      * @return label field
      */
     protected final JTextField getLabelField() {
@@ -240,7 +262,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the placeholder realizing the indentation of the {@link Proposition} contents.
-     * 
+     *
      * @return indentation area
      */
     protected final JPanel getIndentationArea() {
@@ -249,7 +271,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the placeholder for upward pointing arrows referring to a {@code partBeforeArrow} of the represented {@link Proposition} (part).
-     * 
+     *
      * @return left arrow stack
      */
     protected final ArrowStack getLeftArrows() {
@@ -268,7 +290,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the origin text container, which is displayed differently in the syntactical and semantical analysis.
-     * 
+     *
      * @return item area containing the origin text
      */
     protected final JPanel getItemArea() {
@@ -277,7 +299,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the placeholder for downward pointing arrows referring to a {@code partAfterArrow} of the represented {@link Proposition} (part).
-     * 
+     *
      * @return right arrow stack
      */
     protected final ArrowStack getRightArrows() {
@@ -296,7 +318,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the translation input field.
-     * 
+     *
      * @return translation field
      */
     protected final JTextField getTranslationField() {
@@ -305,7 +327,7 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
 
     /**
      * Getter for the represented {@link Proposition}.
-     * 
+     *
      * @return represented model element
      */
     @Override
@@ -338,6 +360,18 @@ abstract class AbstractProposition extends AbstractCommentable<Proposition> impl
         this.contentPane.setSize(this.contentPane.getPreferredSize());
         // make sure it is still displayed
         this.itemArea.validate();
+    }
+
+    /**
+     * resets the tool tip info containing the comment text regarding its value in the represented {@link Proposition}.
+     */
+    public void refreshComment() {
+        final String comment = this.getRepresented().getComment();
+        if (comment == null || comment.isEmpty()) {
+            this.setToolTipText(null);
+        } else {
+            this.setToolTipText(comment);
+        }
     }
 
     @Override

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/SynProposition.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/SynProposition.java
@@ -22,8 +22,6 @@ package org.hmx.scitos.hmx.view.swing.elements;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -59,7 +57,7 @@ public final class SynProposition extends AbstractProposition {
 
     /**
      * Constructor.
-     * 
+     *
      * @param viewReference
      *            the containing view, providing access to higher functions
      * @param represented
@@ -131,6 +129,19 @@ public final class SynProposition extends AbstractProposition {
     }
 
     /**
+     * Create a {@link Dimension} for the indentation by settings its width regarding to the width of the view representation of the
+     * {@code partBeforeArrow}.
+     *
+     * @param partBeforeArrow
+     *            view representation of the {@code partBeforeArrow}
+     * @return {@link Dimension} representing the indentation
+     */
+    private static Dimension createIndentationAfterArrow(final SynProposition partBeforeArrow) {
+        return new Dimension(partBeforeArrow.getIndentationArea().getPreferredSize().width
+                + partBeforeArrow.getLeftArrows().getPreferredSize().width + partBeforeArrow.getItemArea().getPreferredSize().width, 1);
+    }
+
+    /**
      * Initialize the {@link JLabel} in the indentation area for displaying its indentation function and an expanding {@link JPanel} on the right to
      * make sure it is always at the left side of its parent and the explicit syntactical functionality by inserting the contained {@link SynItem}s,
      * adding a listener to the translation field and activating the comment listener.
@@ -157,34 +168,19 @@ public final class SynProposition extends AbstractProposition {
         rightSpacing.gridx = 1;
         rightSpacing.gridy = 0;
         this.add(new JPanel(), rightSpacing);
-        this.getTranslationField().addFocusListener(new FocusAdapter() {
-
-            @Override
-            public void focusLost(final FocusEvent event) {
-                final String translationText = SynProposition.this.getTranslationField().getText();
-                if (!ComparisonUtil.isNullOrEmptyAwareEqual(translationText, SynProposition.this.getRepresented().getSynTranslation())) {
-                    // only transfer if necessary
-                    SynProposition.this.getModelHandler().setSynTranslation(SynProposition.this.getRepresented(), translationText);
-                }
-            }
-        });
         for (final ClauseItem singleItem : this.getRepresented()) {
             this.insertItem(singleItem);
         }
         this.refreshComment();
     }
 
-    /**
-     * Create a {@link Dimension} for the indentation by settings its width regarding to the width of the view representation of the
-     * {@code partBeforeArrow}.
-     *
-     * @param partBeforeArrow
-     *            view representation of the {@code partBeforeArrow}
-     * @return {@link Dimension} representing the indentation
-     */
-    private static Dimension createIndentationAfterArrow(final SynProposition partBeforeArrow) {
-        return new Dimension(partBeforeArrow.getIndentationArea().getPreferredSize().width
-                + partBeforeArrow.getLeftArrows().getPreferredSize().width + partBeforeArrow.getItemArea().getPreferredSize().width, 1);
+    @Override
+    protected void submitTranslationChanges() {
+        final String translationText = this.getTranslationField().getText();
+        // only transfer if necessary
+        if (!ComparisonUtil.isNullOrEmptyAwareEqual(translationText, this.getRepresented().getSynTranslation())) {
+            this.getModelHandler().setSynTranslation(this.getRepresented(), translationText);
+        }
     }
 
     /**
@@ -213,7 +209,7 @@ public final class SynProposition extends AbstractProposition {
 
     /**
      * Getter for the contained {@link SynItem}s.
-     * 
+     *
      * @return displayed {@link SynItem}s
      */
     public List<SynItem> getItems() {
@@ -247,18 +243,6 @@ public final class SynProposition extends AbstractProposition {
     public void refreshTranslation() {
         this.getTranslationField().setText(this.getRepresented().getSynTranslation());
         super.refreshTranslation();
-    }
-
-    /**
-     * Update the tool tip info containing the comment text to match its value in the represented {@link Proposition}.
-     */
-    public void refreshComment() {
-        final String comment = this.getRepresented().getComment();
-        if (comment == null || comment.isEmpty()) {
-            this.setToolTipText(null);
-        } else {
-            this.setToolTipText(comment);
-        }
     }
 
     @Override

--- a/scitos.hmx/scitos.hmx.view/src/test/java/org/hmx/scitos/hmx/view/swing/HmxViewProjectTest.java
+++ b/scitos.hmx/scitos.hmx.view/src/test/java/org/hmx/scitos/hmx/view/swing/HmxViewProjectTest.java
@@ -1,0 +1,130 @@
+/*
+   Copyright (C) 2017 HermeneutiX.org
+
+   This file is part of SciToS.
+
+   SciToS is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   SciToS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with SciToS. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.hmx.scitos.hmx.view.swing;
+
+import org.assertj.swing.fixture.JPanelFixture;
+import org.hmx.scitos.core.i18n.Message;
+import org.hmx.scitos.view.FileType;
+import org.hmx.scitos.view.swing.AbstractScitosUiTest;
+import org.hmx.scitos.view.swing.util.OrdinalComponentMatcher;
+import org.junit.Test;
+
+import org.assertj.swing.fixture.JButtonFixture;
+import org.assertj.swing.fixture.JTextComponentFixture;
+import org.hmx.scitos.hmx.core.i18n.HmxMessage;
+import org.hmx.scitos.hmx.view.swing.elements.SynProposition;
+
+/** UI test for a simple HermeneutiX project workflow. */
+public class HmxViewProjectTest extends AbstractScitosUiTest {
+
+	/**
+	 * Test of the input view of a newly created HermeneutiX project with the following steps:
+	 * <ol>
+	 * <li>create a new/empty HermeneutiX project,</li>
+	 * <li>enter a single character as origin text,</li>
+	 * <li>trigger "Undo",</li>
+	 * <li>trigger "Redo".</li>
+	 * </ol>
+	 */
+	@Test
+	public void testUndoRedoOnInputView() {
+		// #1 create a new/empty HermeneutiX project
+		this.createNewFile(FileType.HMX);
+		this.projectTree.requireSelection(HmxMessage.PROJECT_UNSAVED.get());
+		// #2 enter a single character as origin text
+		final JTextComponentFixture originTextPane = this.frame.textBox("Origin Text Input");
+		originTextPane.enterText("X");
+		// #3 trigger "Undo"
+		final JButtonFixture undoButton = this.getUndoToolBarButton();
+		final JButtonFixture redoButton = this.getRedoToolBarButton();
+		redoButton.requireDisabled();
+		undoButton.requireEnabled().click().requireDisabled();
+		originTextPane.requireText("");
+		// #4 trigger "Redo"
+		redoButton.requireEnabled().click().requireDisabled();
+		originTextPane.requireText("X");
+		undoButton.requireEnabled();
+	}
+
+	/**
+	 * Test of the analysis view of a newly created HermeneutiX project with the following steps:
+	 * <ol>
+	 * <li>create a new/empty HermeneutiX project,</li>
+	 * <li>enter a single character as origin text,</li>
+     * <li>start analysis,</li>
+     * <li>ignore project info input dialog,</li>
+     * <li>enter single character as translation for first Proposition,</li>
+     * <li>enter single character as label for first Proposition,</li>
+	 * <li>trigger "Undo" once,</li>
+	 * <li>trigger "Undo" a second time,</li>
+	 * <li>trigger "Redo" once,</li>
+	 * <li>trigger "Redo" a second time.</li>
+	 * </ol>
+	 */
+	@Test
+	public void testUndoRedoOnAnalysisView() {
+		// #1 create a new/empty HermeneutiX project
+		this.createNewFile(FileType.HMX);
+		this.projectTree.requireSelection(HmxMessage.PROJECT_UNSAVED.get());
+		// #2 enter a single character as origin text
+		final JTextComponentFixture originTextPane = this.frame.textBox("Origin Text Input").enterText("X");
+        // #3 start analysis
+		this.getButtonByText(HmxMessage.TEXTINPUT_START_BUTTON).click();
+        // #4 ignore project info input dialog
+        this.getButtonByText(Message.CANCEL).click();
+        // #5 enter single character as translation for first Proposition
+        this.getSynPropositionTranslationInput(0).enterText("T");
+		final JButtonFixture undoButton = this.getUndoToolBarButton().requireDisabled();
+		final JButtonFixture redoButton = this.getRedoToolBarButton().requireDisabled();
+        // #6 enter single character as label for first Proposition
+        this.getSynPropositionLabelInput(0).enterText("L");
+        // #7 trigger "Undo" once
+        redoButton.requireDisabled();
+        undoButton.requireEnabled().click().requireEnabled();
+        this.getSynPropositionTranslationInput(0).requireText("T");
+        this.getSynPropositionLabelInput(0).requireEmpty();
+        // #8 trigger "Undo" a second time
+        redoButton.requireEnabled();
+        undoButton.requireEnabled().click().requireDisabled();
+        this.getSynPropositionTranslationInput(0).requireEmpty();
+        this.getSynPropositionLabelInput(0).requireEmpty();
+        // #9 trigger "Redo" once
+        redoButton.requireEnabled().click().requireEnabled();
+        undoButton.requireEnabled();
+        getSynPropositionTranslationInput(0).requireText("T");
+        // #10 trigger "Redo" a second time
+        redoButton.requireEnabled().click().requireDisabled();
+        undoButton.requireEnabled();
+        getSynPropositionTranslationInput(0).requireText("T");
+        this.getSynPropositionLabelInput(0).requireText("L");
+    }
+
+    private JPanelFixture getSynProposition(final int index) {
+        return this.frame.panel(new OrdinalComponentMatcher<SynProposition>(SynProposition.class, index, true));
+    }
+
+    private JTextComponentFixture getSynPropositionTranslationInput(final int Index) {
+        return this.getSynProposition(Index).textBox("Translation Input");
+    }
+
+    private JTextComponentFixture getSynPropositionLabelInput(final int Index) {
+        return this.getSynProposition(Index).textBox("Label Input");
+    }
+}

--- a/scitos.hmx/scitos.hmx.view/src/test/java/org/hmx/scitos/hmx/view/swing/HmxViewProjectTest.java
+++ b/scitos.hmx/scitos.hmx.view/src/test/java/org/hmx/scitos/hmx/view/swing/HmxViewProjectTest.java
@@ -34,65 +34,65 @@ import org.hmx.scitos.hmx.view.swing.elements.SynProposition;
 /** UI test for a simple HermeneutiX project workflow. */
 public class HmxViewProjectTest extends AbstractScitosUiTest {
 
-	/**
-	 * Test of the input view of a newly created HermeneutiX project with the following steps:
-	 * <ol>
-	 * <li>create a new/empty HermeneutiX project,</li>
-	 * <li>enter a single character as origin text,</li>
-	 * <li>trigger "Undo",</li>
-	 * <li>trigger "Redo".</li>
-	 * </ol>
-	 */
-	@Test
-	public void testUndoRedoOnInputView() {
-		// #1 create a new/empty HermeneutiX project
-		this.createNewFile(FileType.HMX);
-		this.projectTree.requireSelection(HmxMessage.PROJECT_UNSAVED.get());
-		// #2 enter a single character as origin text
-		final JTextComponentFixture originTextPane = this.frame.textBox("Origin Text Input");
-		originTextPane.enterText("X");
-		// #3 trigger "Undo"
-		final JButtonFixture undoButton = this.getUndoToolBarButton();
-		final JButtonFixture redoButton = this.getRedoToolBarButton();
-		redoButton.requireDisabled();
-		undoButton.requireEnabled().click().requireDisabled();
-		originTextPane.requireText("");
-		// #4 trigger "Redo"
-		redoButton.requireEnabled().click().requireDisabled();
-		originTextPane.requireText("X");
-		undoButton.requireEnabled();
-	}
+    /**
+     * Test of the input view of a newly created HermeneutiX project with the following steps:
+     * <ol>
+     * <li>create a new/empty HermeneutiX project,</li>
+     * <li>enter a single character as origin text,</li>
+     * <li>trigger "Undo",</li>
+     * <li>trigger "Redo".</li>
+     * </ol>
+     */
+    @Test
+    public void testUndoRedoOnInputView() {
+        // #1 create a new/empty HermeneutiX project
+        this.createNewFile(FileType.HMX);
+        this.projectTree.requireSelection(HmxMessage.PROJECT_UNSAVED.get());
+        // #2 enter a single character as origin text
+        final JTextComponentFixture originTextPane = this.frame.textBox("Origin Text Input");
+        originTextPane.enterText("X");
+        // #3 trigger "Undo"
+        final JButtonFixture undoButton = this.getUndoToolBarButton();
+        final JButtonFixture redoButton = this.getRedoToolBarButton();
+        redoButton.requireDisabled();
+        undoButton.requireEnabled().click().requireDisabled();
+        originTextPane.requireText("");
+        // #4 trigger "Redo"
+        redoButton.requireEnabled().click().requireDisabled();
+        originTextPane.requireText("X");
+        undoButton.requireEnabled();
+    }
 
-	/**
-	 * Test of the analysis view of a newly created HermeneutiX project with the following steps:
-	 * <ol>
-	 * <li>create a new/empty HermeneutiX project,</li>
-	 * <li>enter a single character as origin text,</li>
+    /**
+     * Test of the analysis view of a newly created HermeneutiX project with the following steps:
+     * <ol>
+     * <li>create a new/empty HermeneutiX project,</li>
+     * <li>enter a single character as origin text,</li>
      * <li>start analysis,</li>
      * <li>ignore project info input dialog,</li>
      * <li>enter single character as translation for first Proposition,</li>
      * <li>enter single character as label for first Proposition,</li>
-	 * <li>trigger "Undo" once,</li>
-	 * <li>trigger "Undo" a second time,</li>
-	 * <li>trigger "Redo" once,</li>
-	 * <li>trigger "Redo" a second time.</li>
-	 * </ol>
-	 */
-	@Test
-	public void testUndoRedoOnAnalysisView() {
-		// #1 create a new/empty HermeneutiX project
-		this.createNewFile(FileType.HMX);
-		this.projectTree.requireSelection(HmxMessage.PROJECT_UNSAVED.get());
-		// #2 enter a single character as origin text
-		final JTextComponentFixture originTextPane = this.frame.textBox("Origin Text Input").enterText("X");
+     * <li>trigger "Undo" once,</li>
+     * <li>trigger "Undo" a second time,</li>
+     * <li>trigger "Redo" once,</li>
+     * <li>trigger "Redo" a second time.</li>
+     * </ol>
+     */
+    @Test
+    public void testUndoRedoOnAnalysisView() {
+        // #1 create a new/empty HermeneutiX project
+        this.createNewFile(FileType.HMX);
+        this.projectTree.requireSelection(HmxMessage.PROJECT_UNSAVED.get());
+        // #2 enter a single character as origin text
+        final JTextComponentFixture originTextPane = this.frame.textBox("Origin Text Input").enterText("X");
         // #3 start analysis
-		this.getButtonByText(HmxMessage.TEXTINPUT_START_BUTTON).click();
+        this.getButtonByText(HmxMessage.TEXTINPUT_START_BUTTON).click();
         // #4 ignore project info input dialog
         this.getButtonByText(Message.CANCEL).click();
         // #5 enter single character as translation for first Proposition
         this.getSynPropositionTranslationInput(0).enterText("T");
-		final JButtonFixture undoButton = this.getUndoToolBarButton().requireDisabled();
-		final JButtonFixture redoButton = this.getRedoToolBarButton().requireDisabled();
+        final JButtonFixture undoButton = this.getUndoToolBarButton().requireDisabled();
+        final JButtonFixture redoButton = this.getRedoToolBarButton().requireDisabled();
         // #6 enter single character as label for first Proposition
         this.getSynPropositionLabelInput(0).enterText("L");
         // #7 trigger "Undo" once


### PR DESCRIPTION
The changes mainly focus on finalizing the unfinished undo/redo implementation for the HermeneutiX module's analysis view.
Additionally, automated UI tests for the HermeneutiX module have been implemented for the undo/redo feature both on the text input view as well as on the analysis view.

Two unrelated changes have been included here as well:

- Changing the default window size (i.e. if no settings are available, e.g. on the very first start) to 1000x700 instead of the previous 800x600.
- The internal order of the two system language models is now being enforced to ensure the stability of the related unit tests.