### PR TITLE
HermeneutiX – hide all details via view preset

### DIFF
--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/IAnalysisViewSettings.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/IAnalysisViewSettings.java
@@ -26,6 +26,8 @@ public interface IAnalysisViewSettings {
 
     /** Preset: showing all details. */
     IAnalysisViewSettings SHOW_ALL = new ReadOnlyViewSettings(true, true, true, true, true, true);
+    /** Preset: showing all details. */
+    IAnalysisViewSettings HIDE_ALL = new ReadOnlyViewSettings(false, false, false, false, false, false);
     /** Preset: syntactical analysis. */
     IAnalysisViewSettings SYNTACTICAL_ANALYSIS = new ReadOnlyViewSettings(true, true, false, true, true, false);
     /** Preset: semantical analysis. */

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/SingleProjectView.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/components/SingleProjectView.java
@@ -538,7 +538,11 @@ public class SingleProjectView extends AbstractProjectView<HmxSwingProject, Peri
      * @see #refresh()
      */
     void applyViewPreset(final IAnalysisViewSettings preset) {
-        this.viewSettings.applyViewPreset(preset);
+        if (this.viewSettings.matchesPreset(preset)) {
+            this.viewSettings.applyViewPreset(IAnalysisViewSettings.HIDE_ALL);
+        } else {
+            this.viewSettings.applyViewPreset(preset);
+        }
         this.manageViewMenuOptions();
         this.manageToolBarItems();
         this.refresh();

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/ViewProposition.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/ViewProposition.java
@@ -200,17 +200,21 @@ public final class ViewProposition extends AbstractCommentable<Proposition> impl
         this.rightArrows = new ArrowStackLabel(false, 0);
 
         final IAnalysisViewSettings viewSettings = viewReference.getViewSettings();
-        final GridBagConstraints checkBoxConstraints = new GridBagConstraints();
-        checkBoxConstraints.gridx = 0;
-        checkBoxConstraints.gridy = 1;
-        if (this.represented.getPartBeforeArrow() == null && (viewSettings.isShowingPropositionIndentations()
-                || viewSettings.isShowingRelations() && this.represented.getSuperOrdinatedRelation() == null)) {
-            this.checkBox.setName("Check Box");
-            this.contentPane.add(this.checkBox, checkBoxConstraints);
-        } else {
-            final JPanel checkBoxDummy = new JPanel(null);
-            checkBoxDummy.setPreferredSize(this.checkBox.getPreferredSize());
-            this.contentPane.add(checkBoxDummy, checkBoxConstraints);
+        if (viewSettings.isShowingPropositionIndentations()
+                || viewSettings.isShowingRelations() && this.represented.getSuperOrdinatedRelation() == null) {
+            // add check box (or placeholder with same width)
+            final GridBagConstraints checkBoxConstraints = new GridBagConstraints();
+            checkBoxConstraints.gridx = 0;
+            checkBoxConstraints.gridy = 1;
+            if (this.represented.getPartBeforeArrow() == null) {
+                this.checkBox.setName("Check Box");
+                this.contentPane.add(this.checkBox, checkBoxConstraints);
+            } else {
+                // a part-after-arrow cannot be selected for merging/indenting with other propositions or including in relations
+                final JPanel checkBoxDummy = new JPanel(null);
+                checkBoxDummy.setPreferredSize(this.checkBox.getPreferredSize());
+                this.contentPane.add(checkBoxDummy, checkBoxConstraints);
+            }
         }
 
         this.labelField = this.initLabel(viewSettings);


### PR DESCRIPTION
When clicking on the currently active view preset, all view toggles are being turned off (as per #25).
Additionally, if due to currently applied view toggles, no check boxes are required on any proposition, they are no longer taking up any space.