### PR TITLE
fix: AIS - improved error handling for bulk import

### DIFF
--- a/scitos.ais/scitos.ais.core/src/main/resources/org/hmx/scitos/ais/core/i18n/AisMessage.xml
+++ b/scitos.ais/scitos.ais.core/src/main/resources/org/hmx/scitos/ais/core/i18n/AisMessage.xml
@@ -73,7 +73,8 @@ Category assignments without a selected replacement are being discarded.</entry>
 	<entry key="Ais.Project.Export.Html">HTML File</entry>
 	<entry key="Ais.Project.Export.Ods">Spreadsheet (only Results)</entry>
 	<entry key="Ais.Project.Import.Interviews.Ods">Import Interviews (from Spreadsheet)</entry>
-	<entry key="Ais.Project.Import.Interviews.Ods.InvalidSpreadsheet">An import spreadsheet should have at least one sheet and at least two columns and rows on that sheet.
+	<entry key="Ais.Project.Import.Interviews.Ods.InvalidSpreadsheet">An import spreadsheet should be an *.ods (OpenDocument Spreadsheet) file.
+It should also have at least one sheet and at least two columns and rows on that sheet.
 
 One column is expected to contain the Participant IDs and another column should contain the associated interview texts.</entry>
 	<entry key="Ais.Project.Import.Interviews.Ods.Preview.Participant">Participant ID</entry>

--- a/scitos.ais/scitos.ais.core/src/main/resources/org/hmx/scitos/ais/core/i18n/AisMessage_de.xml
+++ b/scitos.ais/scitos.ais.core/src/main/resources/org/hmx/scitos/ais/core/i18n/AisMessage_de.xml
@@ -76,7 +76,8 @@ Zugeordnete Kategorien ohne Entsprechung im neuen Modell werden verworfen!</entr
 	<entry key="Ais.Project.Export.Html">HTML-Datei</entry>
 	<entry key="Ais.Project.Export.Ods">ODS-Datei (Ergebnistabellen)</entry>
 	<entry key="Ais.Project.Import.Interviews.Ods">Importiere Interviews (aus ODS-Spreadsheet)</entry>
-	<entry key="Ais.Project.Import.Interviews.Ods.InvalidSpreadsheet">Ein Spreadsheet kann nur für den Import verwendet werden, wenn es mindesten ein Tabellenblatt enthält, mit mindestens zwei Spalten und zwei Zeilen.
+	<entry key="Ais.Project.Import.Interviews.Ods.InvalidSpreadsheet">Ein Import-Spreadsheet sollte vom Typ *.ods (OpenDocument Spreadsheet) sein.
+Darüber hinaus sollte es mindestens ein Tabellenblatt enthalten, mit mindestens zwei Spalten und zwei Zeilen.
 
 Eine Spalte sollte den Bezeichner der Studienteilnehmer enthalten und die andere Spalte die Interview-Mitschrift.</entry>
 	<entry key="Ais.Project.Import.Interviews.Ods.Preview.Participant">Teilnehmer</entry>

--- a/scitos.ais/scitos.ais.view/src/main/java/org/hmx/scitos/ais/view/swing/AisViewProject.java
+++ b/scitos.ais/scitos.ais.view/src/main/java/org/hmx/scitos/ais/view/swing/AisViewProject.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.stream.IntStream;
 import javax.swing.SwingUtilities;
 import org.hmx.scitos.ais.core.AisModelHandler;
 import org.hmx.scitos.ais.core.i18n.AisMessage;
@@ -224,8 +225,16 @@ public final class AisViewProject implements IViewProject<AisProject>, ModelChan
             return;
         }
         try {
-            final SpreadSheet importFile = SpreadSheet.createFromFile(path);
-            if (importFile.getSheetCount() == 0) {
+            final SpreadSheet importFile;
+            try {
+                importFile = SpreadSheet.createFromFile(path);
+            } catch (NullPointerException ex) {
+                throw new HmxException(AisMessage.PROJECT_IMPORT_INTERVIEWS_INVALID_SPREADSHEET, ex);
+            }
+            if (IntStream.range(0, importFile.getSheetCount())
+                    .mapToObj(importFile::getSheet)
+                    .filter(sheet -> sheet.getColumnCount() > 1 && sheet.getRowCount() > 1)
+                    .noneMatch(sheet -> !sheet.getImmutableCellAt(0, 0).isEmpty() && !sheet.getImmutableCellAt(1, 0).isEmpty())) {
                 throw new HmxException(AisMessage.PROJECT_IMPORT_INTERVIEWS_INVALID_SPREADSHEET);
             }
             new SpreadsheetInterviewImportDialog(this.modelHandler, importFile).setVisible(true);

--- a/scitos.ais/scitos.ais.view/src/main/java/org/hmx/scitos/ais/view/swing/components/SpreadsheetInterviewImportDialog.java
+++ b/scitos.ais/scitos.ais.view/src/main/java/org/hmx/scitos/ais/view/swing/components/SpreadsheetInterviewImportDialog.java
@@ -82,6 +82,7 @@ public final class SpreadsheetInterviewImportDialog extends JDialog {
         this.sheetSelection = new JComboBox<>(IntStream.range(0, spreadsheet.getSheetCount())
                 .mapToObj(spreadsheet::getSheet)
                 .filter(sheet -> sheet.getColumnCount() > 1 && sheet.getRowCount() > 1)
+                .filter(sheet -> !sheet.getImmutableCellAt(0, 0).isEmpty() && !sheet.getImmutableCellAt(1, 0).isEmpty())
                 .map(SheetComboBoxItem::new)
                 .toArray(SheetComboBoxItem[]::new));
         contentPane.add(this.createSelectionForm(), BorderLayout.NORTH);


### PR DESCRIPTION
Improvement of the error handling of the bulk import introduced in #27.

This should make it more obvious that an *.ods file is being expected and also properly ignores empty sheets.