### PR TITLE
HermeneutiX: Relations are sometimes not correctly displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `scitos-hmx`
+#### Fixed
+- in some situations, relations are not properly displayed
 
 ## [2.4.0] - 2020-09-13
 ### `scitos`

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.hmx</groupId>
 	<artifactId>scitos</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.4.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>scitos</name>
 	<description>parent project of SciToS</description>
@@ -31,7 +31,6 @@
     </scm>
 
 	<properties>
-		<scitos.version>2.5.0-SNAPSHOT</scitos.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
@@ -148,55 +147,55 @@
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.domain</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.core</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.view</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.view</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 				<type>test-jar</type>
 			</dependency>
 			<!-- SciToS module: AIS -->
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.ais.domain</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.ais.core</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.ais.view</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<!-- SciToS module: HmX -->
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.hmx.domain</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.hmx.core</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hmx</groupId>
 				<artifactId>scitos.hmx.view</artifactId>
-				<version>${scitos.version}</version>
+				<version>${project.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/scitos.ais/pom.xml
+++ b/scitos.ais/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.ais</artifactId>
 	<packaging>pom</packaging>

--- a/scitos.ais/scitos.ais.core/pom.xml
+++ b/scitos.ais/scitos.ais.core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos.ais</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.ais.core</artifactId>
 	<name>scitos.ais.core</name>

--- a/scitos.ais/scitos.ais.domain/pom.xml
+++ b/scitos.ais/scitos.ais.domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos.ais</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.ais.domain</artifactId>
 	<description>domain project of the SciToS module AIS</description>

--- a/scitos.ais/scitos.ais.view/pom.xml
+++ b/scitos.ais/scitos.ais.view/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos.ais</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.ais.view</artifactId>
 	<name>scitos.ais.view</name>

--- a/scitos.core/pom.xml
+++ b/scitos.core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.core</artifactId>
 	<name>scitos.core</name>

--- a/scitos.distribution/build-mac-app.sh
+++ b/scitos.distribution/build-mac-app.sh
@@ -3,7 +3,7 @@
 # Special script for creating a Mac .app Bundle.
 # This is not portable, needs to be triggered manually and the following parameters need to be adjusted accordingly.
 #
-VERSION="2.4.0"
+VERSION="2.4.1"
 JDK_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
 JRE_MODULES="java.base,java.compiler,java.desktop,java.prefs,java.scripting,java.sql.rowset,jdk.unsupported"
 

--- a/scitos.distribution/pom.xml
+++ b/scitos.distribution/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.distribution</artifactId>
 

--- a/scitos.domain/pom.xml
+++ b/scitos.domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.domain</artifactId>
 	<name>scitos.domain</name>

--- a/scitos.hmx/pom.xml
+++ b/scitos.hmx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.hmx</artifactId>
 	<packaging>pom</packaging>

--- a/scitos.hmx/scitos.hmx.core/pom.xml
+++ b/scitos.hmx/scitos.hmx.core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos.hmx</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.hmx.core</artifactId>
 	<name>scitos.hmx.core</name>

--- a/scitos.hmx/scitos.hmx.core/src/test/java/org/hmx/scitos/hmx/core/ModelParseServiceImplTest.java
+++ b/scitos.hmx/scitos.hmx.core/src/test/java/org/hmx/scitos/hmx/core/ModelParseServiceImplTest.java
@@ -179,8 +179,6 @@ public class ModelParseServiceImplTest {
         this.assertStringEqualsNullOrEmptyAware("Comment differs", expected.getComment(), actual.getComment());
         // iterate over the contained Propositions and their super ordinated Relations, thereby producing helpful output in case of an error
         this.assertPropositionListEquals(expected.getText(), actual.getText(), new HashSet<>());
-        // this covers the whole model but does not provide a helpful error message
-        Assert.assertEquals(expected, actual);
     }
 
     private void assertPropositionListEquals(final List<Proposition> expected, final List<Proposition> actual,

--- a/scitos.hmx/scitos.hmx.domain/pom.xml
+++ b/scitos.hmx/scitos.hmx.domain/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos.hmx</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.hmx.domain</artifactId>
 	<description>domain project of the SciToS module HmX</description>

--- a/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/IPropositionParent.java
+++ b/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/IPropositionParent.java
@@ -65,15 +65,4 @@ public interface IPropositionParent {
      *            the {@link Proposition} to remove
      */
     void removeChildProposition(final Proposition toDelete);
-
-    /**
-     * Check if this element is equal to the given {@code Object}.
-     *
-     * @param otherObj
-     *            other element to be compared with
-     * @param ignoreChildren
-     *            if contained child propositions should be ignored in the comparison
-     * @return if this element is equal to the given {@code Object}
-     */
-    boolean equals(Object otherObj, boolean ignoreChildren);
 }

--- a/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/AbstractConnectable.java
+++ b/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/AbstractConnectable.java
@@ -21,9 +21,9 @@ package org.hmx.scitos.hmx.domain.model;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.UUID;
 
 import org.hmx.scitos.domain.util.CollectionUtil;
-import org.hmx.scitos.domain.util.ComparisonUtil;
 import org.hmx.scitos.hmx.domain.ICommentable;
 import org.hmx.scitos.hmx.domain.IPropositionParent;
 import org.hmx.scitos.hmx.domain.model.RelationTemplate.AssociateRole;
@@ -34,12 +34,22 @@ import org.hmx.scitos.hmx.domain.model.RelationTemplate.AssociateRole;
  */
 public abstract class AbstractConnectable implements Serializable, ICommentable {
 
+    /** Run-time identifier of this model element. */
+    private final UUID id;
+
     /** The super ordinated relation this is an associate of. */
     private Relation superOrdinatedRelation;
     /** The role in the super ordinated relation. */
     private AssociateRole role;
     /** The additional comment's text. */
     private String comment;
+
+    /**
+     * Constructor: setting the internal run-time identifier (generating one if necessary).
+     */
+    protected AbstractConnectable() {
+        this.id = UUID.randomUUID();
+    }
 
     /**
      * Getter for the super ordinated relation this is an associate of.
@@ -209,7 +219,7 @@ public abstract class AbstractConnectable implements Serializable, ICommentable 
 
     @Override
     public int hashCode() {
-        return 3 * (this.role == null ? 0 : this.role.hashCode()) + (this.comment == null ? 0 : this.comment.hashCode());
+        return this.id.hashCode();
     }
 
     @Override
@@ -221,22 +231,7 @@ public abstract class AbstractConnectable implements Serializable, ICommentable 
             return false;
         }
         final AbstractConnectable otherConnectable = (AbstractConnectable) otherObj;
-        if (this.superOrdinatedRelation == null) {
-            return otherConnectable.superOrdinatedRelation == null && this.equalsIgnoreSuperOrdinatedRelation(otherConnectable);
-        }
-        return this.superOrdinatedRelation.equals(otherConnectable.superOrdinatedRelation);
-    }
-
-    /**
-     * Check if this is equal to the given {@code AbstractConnectable}, disregarding any super ordinated {@link Relation}.
-     *
-     * @param otherConnectable
-     *            other element to check for equal connection properties
-     * @return if the connection weight, role and comment are equal
-     */
-    protected boolean equalsIgnoreSuperOrdinatedRelation(final AbstractConnectable otherConnectable) {
-        return ComparisonUtil.isNullAwareEqual(this.role, otherConnectable.role)
-                && ComparisonUtil.isNullOrEmptyAwareEqual(this.comment, otherConnectable.comment);
+        return this.id.equals(otherConnectable.id);
     }
 
     /**

--- a/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/Pericope.java
+++ b/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/Pericope.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import org.hmx.scitos.domain.IModel;
 import org.hmx.scitos.domain.util.CollectionUtil;
-import org.hmx.scitos.domain.util.ComparisonUtil;
 import org.hmx.scitos.hmx.domain.ICommentable;
 import org.hmx.scitos.hmx.domain.IPropositionParent;
 import org.hmx.scitos.hmx.domain.ISyntacticalFunctionProvider;
@@ -486,36 +485,5 @@ public final class Pericope implements IModel<Pericope>, IPropositionParent, ICo
             clonedAssociates.add(clonedAssociate);
         }
         clonedSubTreeHead.setAssociates(clonedAssociates);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = this.languageModel.hashCode();
-        result += this.author == null ? 0 : this.author.hashCode();
-        result *= 3;
-        result += this.title == null ? 0 : this.title.hashCode();
-        result *= 5;
-        result += this.comment == null ? 0 : this.comment.hashCode();
-        return result * this.text.size();
-    }
-
-    @Override
-    public boolean equals(final Object otherObj) {
-        return this.equals(otherObj, false);
-    }
-
-    @Override
-    public boolean equals(final Object otherObj, final boolean ignoreChildren) {
-        if (this == otherObj) {
-            return true;
-        }
-        if (!(otherObj instanceof Pericope)) {
-            return false;
-        }
-        final Pericope otherPericope = (Pericope) otherObj;
-        return this.languageModel.equals(otherPericope.languageModel) && ComparisonUtil.isNullOrEmptyAwareEqual(this.author, otherPericope.author)
-                && ComparisonUtil.isNullOrEmptyAwareEqual(this.title, otherPericope.title)
-                && ComparisonUtil.isNullOrEmptyAwareEqual(this.comment, otherPericope.comment)
-                && (ignoreChildren || this.text.equals(otherPericope.text));
     }
 }

--- a/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/Proposition.java
+++ b/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/Proposition.java
@@ -26,7 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.hmx.scitos.domain.util.CollectionUtil;
-import org.hmx.scitos.domain.util.ComparisonUtil;
 import org.hmx.scitos.hmx.domain.ICanHaveSyntacticalFunction;
 import org.hmx.scitos.hmx.domain.IPropositionParent;
 
@@ -551,67 +550,17 @@ public final class Proposition extends AbstractConnectable implements Cloneable,
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result += this.label == null ? 0 : this.label.hashCode();
-        result *= 3;
-        result += this.function == null ? 0 : this.function.hashCode();
-        result *= 5;
-        result += this.synTranslation == null ? 0 : this.synTranslation.hashCode();
-        result *= 7;
-        result += this.semTranslation == null ? 0 : this.semTranslation.hashCode();
-        return result * this.items.size();
+        return super.hashCode();
     }
 
     @Override
     public boolean equals(final Object otherObj) {
-        return this.equals(otherObj, false);
-    }
-
-    @Override
-    public boolean equals(final Object otherObj, final boolean ignoreChildren) {
         if (this == otherObj) {
             return true;
         }
         if (!(otherObj instanceof Proposition)) {
             return false;
         }
-        final Proposition otherProposition = (Proposition) otherObj;
-        if (this.partBeforeArrow == null && otherProposition.partBeforeArrow == null) {
-            // first of the (possibly multiple) proposition parts established
-            return this.equalsIgnorePartBeforeArrow(otherProposition, ignoreChildren);
-        }
-        if (this.partBeforeArrow != null && otherProposition.partBeforeArrow != null) {
-            // check part before arrow as well
-            return this.partBeforeArrow.equals(otherProposition.partBeforeArrow, ignoreChildren);
-        }
-        return false;
-    }
-
-    /**
-     * Check if this is equal to the given {@code Proposition}, disregarding any potential {@code partBeforeArrow}.
-     *
-     * @param otherProposition
-     *            the other element to compare with
-     * @param ignoreChildren
-     *            if subordinated {@link Proposition}s should also be excluded from this check
-     * @return if the given {@link Proposition} is equal to this one (under the given constraints)
-     */
-    private boolean equalsIgnorePartBeforeArrow(final Proposition otherProposition, final boolean ignoreChildren) {
-        if (this.partAfterArrow == null) {
-            if (otherProposition.partAfterArrow != null) {
-                return false;
-            }
-        } else if (otherProposition.partAfterArrow == null
-                || !this.partAfterArrow.equalsIgnorePartBeforeArrow(otherProposition.partAfterArrow, ignoreChildren)) {
-            return false;
-        }
-        return super.equals(otherProposition) && ComparisonUtil.isNullOrEmptyAwareEqual(this.label, otherProposition.label)
-                && ComparisonUtil.isNullAwareEqual(this.function, otherProposition.function)
-                && ComparisonUtil.isNullOrEmptyAwareEqual(this.synTranslation, otherProposition.synTranslation)
-                && ComparisonUtil.isNullOrEmptyAwareEqual(this.semTranslation, otherProposition.semTranslation)
-                && ComparisonUtil.isNullOrEmptyAwareEqual(this.items, otherProposition.items)
-                && (ignoreChildren || ComparisonUtil.isNullOrEmptyAwareEqual(this.priorChildren, otherProposition.priorChildren))
-                && (ignoreChildren || ComparisonUtil.isNullOrEmptyAwareEqual(this.laterChildren, otherProposition.laterChildren))
-                && this.parent.equals(otherProposition.parent, true);
+        return super.equals(otherObj);
     }
 }

--- a/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/Relation.java
+++ b/scitos.hmx/scitos.hmx.domain/src/main/java/org/hmx/scitos/hmx/domain/model/Relation.java
@@ -151,7 +151,7 @@ public final class Relation extends AbstractConnectable implements Cloneable, It
     }
 
     /**
-     * Create an empty copy of this {@link Relation} WITHOUT setting its sub ordinated associates.
+     * Create an empty copy of this {@link Relation} WITHOUT setting its subordinated associates.
      *
      * @return the cloned Relation, holding only its comment
      */
@@ -164,7 +164,7 @@ public final class Relation extends AbstractConnectable implements Cloneable, It
 
     @Override
     public int hashCode() {
-        return super.hashCode() + this.associates.size();
+        return super.hashCode();
     }
 
     @Override
@@ -175,25 +175,6 @@ public final class Relation extends AbstractConnectable implements Cloneable, It
         if (!(otherObj instanceof Relation)) {
             return false;
         }
-        // equals() of the AbstractConnectable class invokes equalsIgnoreSuperOrdinatedRelation()
         return super.equals(otherObj);
-    }
-
-    @Override
-    protected boolean equalsIgnoreSuperOrdinatedRelation(final AbstractConnectable otherConnectable) {
-        if (!(otherConnectable instanceof Relation)) {
-            return false;
-        }
-        final Relation otherRelation = (Relation) otherConnectable;
-        final int associateCount = this.associates.size();
-        if (associateCount != otherRelation.associates.size()) {
-            return false;
-        }
-        for (int associateIndex = 0; associateIndex < associateCount; associateIndex++) {
-            if (!this.associates.get(associateIndex).equalsIgnoreSuperOrdinatedRelation(otherRelation.associates.get(associateIndex))) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/scitos.hmx/scitos.hmx.view/pom.xml
+++ b/scitos.hmx/scitos.hmx.view/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos.hmx</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.hmx.view</artifactId>
 	<name>scitos.hmx.view</name>

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/ViewProposition.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/ViewProposition.java
@@ -31,6 +31,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
@@ -749,5 +750,10 @@ public final class ViewProposition extends AbstractCommentable<Proposition> impl
         if (this.semTranslationField != null) {
             this.semTranslationField.setToolTipText(toolTip);
         }
+    }
+
+    @Override
+    public String toString() {
+        return this.getRepresented().getItems().stream().map(ClauseItem::getOriginText).collect(Collectors.joining(" "));
     }
 }

--- a/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/ViewRelation.java
+++ b/scitos.hmx/scitos.hmx.view/src/main/java/org/hmx/scitos/hmx/view/swing/elements/ViewRelation.java
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JTextField;
@@ -40,6 +42,7 @@ import javax.swing.border.Border;
 import org.hmx.scitos.core.option.Option;
 import org.hmx.scitos.hmx.core.option.HmxGeneralOption;
 import org.hmx.scitos.hmx.domain.model.AbstractConnectable;
+import org.hmx.scitos.hmx.domain.model.ClauseItem;
 import org.hmx.scitos.hmx.domain.model.Pericope;
 import org.hmx.scitos.hmx.domain.model.Proposition;
 import org.hmx.scitos.hmx.domain.model.Relation;
@@ -250,8 +253,17 @@ public final class ViewRelation extends AbstractCommentable<Relation> implements
             verticalPos = startX - (2 * ViewRelation.HALF_LINE_THICKNESS);
         }
         final Rectangle verticalLine =
-                new Rectangle(verticalPos, horizontalLines.get(0), (2 * ViewRelation.HALF_LINE_THICKNESS), (horizontalLines.get(horizontalLines
-                        .size() - 1) - horizontalLines.get(0)) + (2 * ViewRelation.HALF_LINE_THICKNESS));
+                new Rectangle(verticalPos, horizontalLines.get(0),
+                        (2 * ViewRelation.HALF_LINE_THICKNESS),
+                        (horizontalLines.get(horizontalLines.size() - 1) - horizontalLines.get(0)) + (2 * ViewRelation.HALF_LINE_THICKNESS));
+        if (horizontalLines.size() > 2) {
+            System.out.println("Drawing Relation:");
+            IntStream.range(0, horizontalLines.size())
+                    .forEach(index -> System.out.println("horizontal: " + horizontalLines.get(index) + " ("
+                            + this.viewAssociates.get(index).toString() + " | " + this.viewAssociates.get(index).getConnectY() + ")"));
+            System.out.println("vertical: " + verticalLine.getY() + " to " + (verticalLine.getY() + verticalLine.height));
+            System.out.println("-------------------------------");
+        }
         graphics2D.draw(verticalLine);
         graphics2D.fill(verticalLine);
         if (this.roleFields != null) {
@@ -444,5 +456,14 @@ public final class ViewRelation extends AbstractCommentable<Relation> implements
         for (final Component singleComponent : this.getComponents()) {
             singleComponent.addMouseListener(listener);
         }
+    }
+
+    @Override
+    public String toString() {
+        return this.getRepresented().getFirstPropositionContained().getItems().stream()
+                    .map(ClauseItem::getOriginText).collect(Collectors.joining(" "))
+                + " - "
+                + this.getRepresented().getLastPropositionContained().getItems().stream()
+                    .map(ClauseItem::getOriginText).collect(Collectors.joining(" "));
     }
 }

--- a/scitos.view/pom.xml
+++ b/scitos.view/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.hmx</groupId>
 		<artifactId>scitos</artifactId>
-		<version>2.5.0-SNAPSHOT</version>
+		<version>2.4.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>scitos.view</artifactId>
 	<name>scitos.view</name>


### PR DESCRIPTION
In some circumstances, one of the horizontal lines (and the associated vertical line) on a relation might be missing.

As it turns out, there was some unnecessary complexity in the code around comparing model elements with each other.

Fix: introducing a randomly generated `UUID` for each model element makes those checks much simpler (and presumably quicker).
Note: the chance for collisions between those randomly generated `UUID`s is about one in a billion (according to [Wikipedia](https://en.wikipedia.org/wiki/Universally_unique_identifier#Collisions)). I.e. there will be a whole lot of other errors before this becomes a concern. 😉