### PR TITLE
fix: Counting of nested AIS details in HTML export

### DIFF
--- a/scitos.ais/scitos.ais.core/src/main/resources/org/hmx/scitos/ais/stylesheet.xsl
+++ b/scitos.ais/scitos.ais.core/src/main/resources/org/hmx/scitos/ais/stylesheet.xsl
@@ -197,7 +197,7 @@ span.detail-end { float: right; }
                                     </xsl:if>
                                 </td>
                                 <td class="number">
-                                    <xsl:value-of select="count(.//ais:Detail//ais:Token)" />
+                                    <xsl:value-of select="count(.//ais:Detail[@code]/ais:Token)" />
                                 </td>
                                 <xsl:variable name="interview" select="." />
                                 <xsl:for-each select="//ais:Categories/ais:Category">
@@ -241,7 +241,7 @@ span.detail-end { float: right; }
                             <xsl:value-of select="concat(' ',@code,' ')" />
                         </xsl:for-each>
                     </xsl:variable>
-                    <xsl:value-of select="count($interview//ais:Detail[contains($childCodes,concat(' ',@code,' '))])" />
+                    <xsl:value-of select="count($interview//ais:Detail[@code and contains($childCodes,concat(' ',@code,' '))])" />
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:value-of select="count($interview//ais:Detail[@code=$category/@code])" />


### PR DESCRIPTION
The count of AIS details in the HTML export is showing too high values if there are nested details I’ve attached a minimal example, to illustrate it, also with the generated HTML file after the fix I made.

- The count inside the application is correct.
- The count of annotated tokens in the HTML export is including also tokens without an assigned category if they are surrounded by an annotated detail.
- The sums of parent/branch categories (e.g, “int” and “Ext”) in the HTML export are higher than the actual sum of their child categories if there are such tokens without an assigned category wrapped by an annotated detail.
- The count of child/leaf categories in the HTML export is correct.

For reference, attached a minimal example AIS project and erroneous HTML export result.
[reproduce-bug.zip](https://github.com/scientific-tool-set/scitos/files/11739356/reproduce-bug.zip)